### PR TITLE
Modify file timestamping to avoid `:` in tarball name

### DIFF
--- a/S3Vendor_go/main.go
+++ b/S3Vendor_go/main.go
@@ -109,7 +109,7 @@ func vendor(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, 
 	os.Unsetenv("AWS_SESSION_TOKEN")
 
 	currentTime := time.Now()
-	fname := fmt.Sprintf("reports/%s-%s.tar.gz", currentTime.Format("2006-01-02T15:04:05"), user.GetLogin())
+	fname := fmt.Sprintf("reports/%s-%s.tar.gz", currentTime.Format("2006-01-02T15-04-05"), user.GetLogin())
 
 	awsSession := session.New()
 	svc := sts.New(awsSession)


### PR DESCRIPTION
Unfortunately, `tar` seems to think that `2020-01-02T16:` constitutes a
URL protocol scheme.  Let's just not use `:` in tarball names.