### PR TITLE
Add test suite, re-org a little

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+S3Vendor_go/S3Vendor_go
+Manifest.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: julia
+julia:
+  - 1.3
+  - 1.4
+  - nightly
+codecov: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: julia
-julia:
-  - 1.3
-  - 1.4
-  - nightly
-codecov: true

--- a/Project.toml
+++ b/Project.toml
@@ -20,3 +20,9 @@ JSON = "0.21"
 Tar = "1.3.0"
 julia = "1.3"
 rr_jll = "5.3.1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/go_compile.jl
+++ b/test/go_compile.jl
@@ -1,0 +1,30 @@
+using Test
+
+# Perhaps someday we'll have a `go_jll`. ;)
+@testset "S3Vendor" begin
+    @test isfile(joinpath(@__DIR__, "..", "S3Vendor_go", "main.go"))
+    cd(joinpath(@__DIR__, "..", "S3Vendor_go")) do
+        # Check to see if `go version` gives us something new enough:
+        if Sys.which("go") === nothing
+            @info("Skipping S3Vendor compile test due to lack of `go` compiler")
+            return
+        end
+        
+        gv = read(`go version`)
+        m = match(r"^go version go([\d\.]+) ", String(read(`go version`)))
+        if m === nothing
+            @info("Skipping S3Vendor compile test due to inability to run `go version` check")
+            return
+        end
+        
+        if VersionNumber(m.captures[1]) < v"1.11"
+            @info("Skipping S3Vendor compile test due to outdated `go` version ($(m.captures[1]) < 1.11)")
+            return
+        end
+
+        @info("Testing that S3Vendor compiles...")
+        run(`go build`)
+        @test isfile("S3Vendor_go")
+        rm("S3Vendor_go")
+    end
+end

--- a/test/rr.jl
+++ b/test/rr.jl
@@ -1,0 +1,67 @@
+using BugReporting, Test, Pkg
+
+@testset "rr" begin
+    try
+        BugReporting.check_rr_available()
+    catch
+        @info("Skipping `rr` tests, as `rr` unavailable on $(Pkg.BinaryPlatforms.platform_key_abi())")
+        return
+    end
+
+    # Test that we can create a replay:
+    mktempdir() do temp_trace_dir
+        msg = "Time is precious, spend it wisely"
+        old_stdout = Base.stdout
+        old_stderr = Base.stderr
+        old_stdin = Base.stdin
+        
+        new_stdout_rd, new_stdout_wr = Base.redirect_stdout()
+        new_stderr_rd, new_stderr_wr = Base.redirect_stderr()
+        BugReporting.rr_record(
+            Base.julia_cmd(),
+            "-e",
+            "println(\"$(msg)\")";
+            trace_dir=temp_trace_dir,
+        )
+        Base.redirect_stdout(old_stdout)
+        Base.redirect_stderr(old_stderr)
+        close(new_stdout_wr)
+        close(new_stderr_wr)
+
+        rr_stdout = String(read(new_stdout_rd))
+        rr_stderr = String(read(new_stderr_rd))
+
+        # Test that Julia spat out what we expect, and nothing was on stderr:
+        @test occursin(msg, rr_stdout)
+        @test isempty(rr_stderr)
+
+        # Test that we get something put into the temp trace directory
+        @test islink(joinpath(temp_trace_dir, "latest-trace"))
+
+        # Test that we can pack the trace directory
+        @test !BugReporting.is_packed(temp_trace_dir)
+        BugReporting.rr_pack(temp_trace_dir)
+        @test BugReporting.is_packed(temp_trace_dir)
+
+        # Test that we can replay that trace: (just send in `continue` immediately to let it run)
+        new_stdout_rd, new_stdout_wr = Base.redirect_stdout()
+        new_stderr_rd, new_stderr_wr = Base.redirect_stderr()
+        new_stdin_rd, new_stdin_wr = Base.redirect_stdin()
+        write(new_stdin_wr, "continue\nquit\ny")
+        BugReporting.rr_replay(temp_trace_dir)
+        Base.redirect_stdout(old_stdout)
+        Base.redirect_stderr(old_stderr)
+        Base.redirect_stdin(old_stdin)
+        close(new_stdout_wr)
+        close(new_stderr_wr)
+        close(new_stdin_rd)
+        
+        rr_stdout = String(read(new_stdout_rd))
+        rr_stderr = String(read(new_stderr_rd))
+
+        # Test that Julia spat out what we expect, and there there was
+        # a LOT of stuff on `rr_stderr`.  :)
+        @test occursin(msg, rr_stdout)
+        @test !isempty(rr_stderr)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,2 @@
+include("go_compile.jl")
+include("rr.jl")


### PR DESCRIPTION
This adds a test suite to record/replay (but sadly not upload) traces.
It also reorganizes things a little bit to provide a slightly more
user-friendly API, and includes compilation of the `go` lambda service
as part of CI when possible