### PR TITLE
Upgrade `deploy.sh` to allow building through docker, reduce necessary configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 S3Vendor_go/S3Vendor_go
+S3Vendor_go/lambda.zip
 Manifest.toml

--- a/S3Vendor_go/deploy.sh
+++ b/S3Vendor_go/deploy.sh
@@ -1,4 +1,24 @@
 #!/bin/sh
-go build
-zip -f lambda.zip S3Vendor_go
-aws lambda update-function-code --function-name github-authentication --zip-file lambda.zip
+
+# Check for a `go` version new enough installed locally
+if [ -n `which go` ]; then
+    GOVERS_MINOR=`go version | sed -E 's/.*go1\.([0-9]+).*/\1/'`
+    if [ -z "${GOVERS_MINOR}" ] || [ "${GOVERS_MINOR}" -lt 11 ]; then
+        echo "go too old or doesn't run properly; autodetected version '1.${GOVERS_MINOR}'" >&2
+    else
+        GO_CMD="go build"
+    fi
+else
+    echo "No go installation found!" >&2
+fi
+
+if [ -z "${GO_CMD}" ] && [ -n `which docker` ]; then
+    echo "Docker found, attempting docker build..."
+    GO_CMD="docker run --rm -ti -v `pwd`:/app -w /app golang /bin/bash -c \"go build && chown `id -u`:`id -g` S3Vendor_go\""
+fi
+
+eval ${GO_CMD}
+
+rm -f lambda.zip
+zip lambda.zip S3Vendor_go
+aws lambda update-function-code --region=us-east-1 --function-name github-authentication --zip-file fileb://lambda.zip


### PR DESCRIPTION
With these changes, I was able to deploy a new version of the `go` code.