### PR TITLE
Switch compression to zstdmt

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+Zstd_jll = "3161d3a3-bdf6-5164-811a-617609db77b4"
 rr_jll = "e86bdf43-55f7-5ea2-9fd0-e7daa2c0f2b4"
 
 [compat]

--- a/S3Vendor_go/main.go
+++ b/S3Vendor_go/main.go
@@ -109,7 +109,7 @@ func vendor(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, 
 	os.Unsetenv("AWS_SESSION_TOKEN")
 
 	currentTime := time.Now()
-	fname := fmt.Sprintf("reports/%s-%s.tar.gz", currentTime.Format("2006-01-02T15-04-05"), user.GetLogin())
+	fname := fmt.Sprintf("reports/%s-%s.tar.zstd", currentTime.Format("2006-01-02T15-04-05"), user.GetLogin())
 
 	awsSession := session.New()
 	svc := sts.New(awsSession)


### PR DESCRIPTION
Seems to be about 6x faster than gzip, but now bottlenecked on
https://github.com/JuliaIO/Tar.jl/issues/33.