### PR TITLE
Use README as docstring and help message

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,13 @@
 
 This is a WIP to simplify bug reporting for julia by enabling users to easily
 upload rr traces (and in the future potentially other report types).
+
+## Available bug report types
+
+### `--bug-report=rr`
+
+Run `julia` inside `rr record` and upload the recorded trace.
+
+### `--bug-report=help`
+
+Print help message and exit.

--- a/src/BugReporting.jl
+++ b/src/BugReporting.jl
@@ -1,5 +1,8 @@
 module BugReporting
 
+# Use README as the docstring of the module:
+@doc read(joinpath(dirname(@__DIR__), "README.md"), String) BugReporting
+
 export replay, make_interactive_report
 
 using rr_jll
@@ -120,8 +123,12 @@ function make_interactive_report(report_type, ARGS=[])
         end
         upload_rr_trace(Pkg.artifact_path(artifact_hash))
         return
+    elseif report_type == "help"
+        show(stdout, "text/plain", @doc(BugReporting))
+        println()
+        return
     end
-    error("Unknown report type")
+    error("Unknown report type: $report_type")
 end
 
 const S3_CHUNK_SIZE = 25 * 1024 * 1024 # 25 MB


### PR DESCRIPTION
This PR lets people read the README via `--bug-report=help` and `?BugReporting`.