### PR TITLE
Fix check of availability of RR

### DIFF
--- a/src/BugReporting.jl
+++ b/src/BugReporting.jl
@@ -17,7 +17,7 @@ const GITHUB_APP_ID = "Iv1.c29a629771fe63c4"
 const TRACE_BUCKET = "julialang-dumps"
 
 function check_rr_available()
-    if isempty(rr_jll.rr_path)
+    if !isdefined(rr_jll, :rr_path)
         error("RR not available on this platform")
     end
 end


### PR DESCRIPTION
The variable `rr_path` is defined by the wrapper of the JLL package, which is
loaded only if the artifact is available for the given platform.  If not, no
wrapper is loaded and the variable is not defined.