### PR TITLE
Enable TagBot

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,11 @@
+name: TagBot
+on:
+  schedule:
+    - cron: 0 0 * * *
+jobs:
+  TagBot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Currently, there are no release tags in https://github.com/JuliaLang/BugReporting.jl/releases.  I think it'd be nice to have tags.