### PR TITLE
Check /proc/sys/kernel/perf_event_paranoid

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,2 +1,3 @@
 include("go_compile.jl")
 include("rr.jl")
+include("unittests.jl")

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1,0 +1,48 @@
+module BugReportingUnitTests
+
+using BugReporting:
+    check_perf_event_paranoid, get_record_flags, InvalidPerfEventParanoidError
+using Test
+
+@testset "get_record_flags" begin
+    @test withenv(get_record_flags, "JULIA_RR_RECORD_ARGS" => "") == String[]
+    @test withenv(get_record_flags, "JULIA_RR_RECORD_ARGS" => " ") == String[]
+    @test withenv(get_record_flags, "JULIA_RR_RECORD_ARGS" => "-n") == ["-n"]
+    @test withenv(get_record_flags, "JULIA_RR_RECORD_ARGS" => " -n ") == ["-n"]
+end
+
+@testset "check_perf_event_paranoid" begin
+    function check(value, flags = "")
+        mktemp() do path, io
+            write(io, value)
+            close(io)
+            withenv("JULIA_RR_RECORD_ARGS" => flags) do
+                check_perf_event_paranoid(path)
+            end
+        end
+        return true
+    end
+    @test check("0")
+    @test check("1")
+    @test_throws InvalidPerfEventParanoidError check("2")
+    @test_throws InvalidPerfEventParanoidError check("3")
+    @test check("2", "-n")
+    @test check("2", "--no-syscall-buffer")
+
+    # Let `rr` handle these?
+    @test check("non integer")
+    withenv("JULIA_RR_RECORD_ARGS" => "") do
+        @test check_perf_event_paranoid("/hopefully/non/existing/path") === nothing
+    end
+
+    err = try
+        check("2")
+    catch err
+        err
+    end
+    @test err isa InvalidPerfEventParanoidError
+    msg = sprint(showerror, err)
+    @test contains(msg, "rr needs /proc/sys/kernel/perf_event_paranoid <= 1, but it is 2")
+end
+
+end  # module


### PR DESCRIPTION
close #21.

Now `julia  --bug-report=rr` fails with the following message when `/proc/sys/kernel/perf_event_paranoid` is not appropriate (or `JULIA_RR_RECORD_ARGS` is not given):

```console
$ julia --bug-report=rr
[ Info: Loading BugReporting package...
ERROR: InvalidPerfEventParanoidError
rr needs /proc/sys/kernel/perf_event_paranoid <= 1, but it is 2.
Change it to 1, or use `JULIA_RR_RECORD_ARGS=-n julia --bug-report=rr` (slow).
Consider putting 'kernel.perf_event_paranoid = 1' in /etc/sysctl.conf
or change it temporarily by
    echo 1 | sudo tee /proc/sys/kernel/perf_event_paranoid

Stacktrace:
 [1] check_perf_event_paranoid(::String) at /home/takafumi/.julia/dev/BugReporting/src/BugReporting.jl:59
 [2] check_perf_event_paranoid at /home/takafumi/.julia/dev/BugReporting/src/BugReporting.jl:54 [inlined]
 [3] rr_record(::Cmd, ::Vararg{Any,N} where N; trace_dir::String) at /home/takafumi/.julia/dev/BugReporting/src/BugReporting.jl:100
 [4] (::BugReporting.var"#15#16"{Array{Any,1},Cmd})(::String) at /home/takafumi/.julia/dev/BugReporting/src/BugReporting.jl:159
 [5] create_artifact(::BugReporting.var"#15#16"{Array{Any,1},Cmd}) at /home/takafumi/repos/watch/julia/usr/share/julia/stdlib/v1.6/Pkg/src/Artifacts.jl:214
 [6] make_interactive_report(::String, ::Array{Any,1}) at /home/takafumi/.julia/dev/BugReporting/src/BugReporting.jl:158
 [7] make_interactive_report(::String) at /home/takafumi/.julia/dev/BugReporting/src/BugReporting.jl:152
 [8] #invokelatest#1 at ./essentials.jl:710 [inlined]
 [9] invokelatest at ./essentials.jl:709 [inlined]
 [10] report_bug(::String) at /home/takafumi/repos/watch/julia/usr/share/julia/stdlib/v1.6/InteractiveUtils/src/InteractiveUtils.jl:379
 [11] exec_options(::Base.JLOptions) at ./client.jl:232
 [12] _start() at ./client.jl:485
```
