### PR TITLE
Use Artifacts directly

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,0 +1,51 @@
+## Note: this Artifacts.toml has been manually constructed!
+#  We have:
+#    - Copied https://raw.githubusercontent.com/JuliaBinaryWrappers/rr_jll.jl/main/Artifacts.toml
+#    - Duplicated all stanzas and replaced `x86_64` with `i686`
+#  This allows us to still use things like `select_downloadable_artifacts()` or just `artifact"rr"`
+#  on both the `i686` and `x86_64` glibc Linux platforms to get a compatible `rr` binary.  We're
+#  purposefully bypassing JLLWrappers and whatnot because we want to run `x86_64` binaries on `i686` machines.
+
+[[rr]]
+arch = "x86_64"
+cxxstring_abi = "cxx03"
+git-tree-sha1 = "68d1f350262c8ccf0c6d2c0a06ffbc8e1bbf11b4"
+libc = "glibc"
+os = "linux"
+
+    [[rr.download]]
+    sha256 = "3dfafbe0eb57999723a249cf5d05c923e05df56f2a4ff5eb0ba3a150e1ba3a89"
+    url = "https://github.com/JuliaBinaryWrappers/rr_jll.jl/releases/download/rr-v5.4.1+5/rr.v5.4.1.x86_64-linux-gnu-cxx03.tar.gz"
+
+[[rr]]
+arch = "x86_64"
+cxxstring_abi = "cxx11"
+git-tree-sha1 = "52f01c25fd3bd6b5a8e78d5eee850c67d9bba5fb"
+libc = "glibc"
+os = "linux"
+
+    [[rr.download]]
+    sha256 = "c7cc00735be80a07f4629656c5881f48c98f917cfccbb0d8f0d9776d799c5825"
+    url = "https://github.com/JuliaBinaryWrappers/rr_jll.jl/releases/download/rr-v5.4.1+5/rr.v5.4.1.x86_64-linux-gnu-cxx11.tar.gz"
+
+[[rr]]
+arch = "i686"
+cxxstring_abi = "cxx03"
+git-tree-sha1 = "68d1f350262c8ccf0c6d2c0a06ffbc8e1bbf11b4"
+libc = "glibc"
+os = "linux"
+
+    [[rr.download]]
+    sha256 = "3dfafbe0eb57999723a249cf5d05c923e05df56f2a4ff5eb0ba3a150e1ba3a89"
+    url = "https://github.com/JuliaBinaryWrappers/rr_jll.jl/releases/download/rr-v5.4.1+5/rr.v5.4.1.x86_64-linux-gnu-cxx03.tar.gz"
+
+[[rr]]
+arch = "i686"
+cxxstring_abi = "cxx11"
+git-tree-sha1 = "52f01c25fd3bd6b5a8e78d5eee850c67d9bba5fb"
+libc = "glibc"
+os = "linux"
+
+    [[rr.download]]
+    sha256 = "c7cc00735be80a07f4629656c5881f48c98f917cfccbb0d8f0d9776d799c5825"
+    url = "https://github.com/JuliaBinaryWrappers/rr_jll.jl/releases/download/rr-v5.4.1+5/rr.v5.4.1.x86_64-linux-gnu-cxx11.tar.gz"

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ AWSS3 = "0.6.11"
 HTTP = "0.8.14"
 JSON = "0.21"
 Tar = "1.3.1"
-julia = "1.3"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -6,12 +6,12 @@ version = "0.1.3"
 [deps]
 AWSCore = "4f1ea46c-232b-54a6-9b17-cc2d0f3e6598"
 AWSS3 = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 Zstd_jll = "3161d3a3-bdf6-5164-811a-617609db77b4"
-rr_jll = "e86bdf43-55f7-5ea2-9fd0-e7daa2c0f2b4"
 
 [compat]
 AWSCore = "0.6.11"
@@ -20,7 +20,6 @@ HTTP = "0.8.14"
 JSON = "0.21"
 Tar = "1.3.1"
 julia = "1.3"
-rr_jll = "5.3.1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/BugReporting.jl
+++ b/src/BugReporting.jl
@@ -6,7 +6,7 @@ module BugReporting
 export replay, make_interactive_report
 
 using Base.Filesystem: uperm
-using Artifacts
+using Artifacts, Base.BinaryPlatforms
 using Zstd_jll
 using HTTP, JSON
 using AWSCore, AWSS3
@@ -25,7 +25,9 @@ const WSS_ENDPOINT = "wss://53ly7yebjg.execute-api.us-east-1.amazonaws.com/test"
 const GITHUB_APP_ID = "Iv1.c29a629771fe63c4"
 const TRACE_BUCKET = "julialang-dumps"
 
-rr() = joinpath(artifact"rr", "bin", "rr")
+function rr(arch = readchomp(`uname -m`))
+    joinpath(@artifact_str("rr", Platform(arch, "linux"; libc="glibc")), "bin", "rr")
+end
 function check_rr_available()
     return isfile(rr())
 end

--- a/test/rr.jl
+++ b/test/rr.jl
@@ -48,7 +48,7 @@ using BugReporting, Test, Pkg
         new_stderr_rd, new_stderr_wr = Base.redirect_stderr()
         new_stdin_rd, new_stdin_wr = Base.redirect_stdin()
         write(new_stdin_wr, "continue\nquit\ny")
-        BugReporting.rr_replay(temp_trace_dir)
+        BugReporting.replay(temp_trace_dir)
         Base.redirect_stdout(old_stdout)
         Base.redirect_stderr(old_stderr)
         Base.redirect_stdin(old_stdin)


### PR DESCRIPTION
This works around our lack of cross-targeting in JLLWrappers by instead
building an `Artifacts.toml` file manually that copies the stanzas from
the actual JLL release, but duplicates the `x86_64` stanzas to `i686`
stanzas.  This means that if we were to actually run this on true `i686`
hardware it would fail, but that is hopefully much less common than
running `i686` binaries on `x86_64` hardware.

We maintain rough API compatibility with JLLWrappers in expectation of
being able to generate a JLL with the appropriate `Artifacts.toml` in
the near future.