### PR TITLE
Bump [compat] for AWSS3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ rr_jll = "e86bdf43-55f7-5ea2-9fd0-e7daa2c0f2b4"
 
 [compat]
 AWSCore = "0.6.11"
-AWSS3 = "0.6.11"
+AWSS3 = "0.6.11, 0.7, 0.8"
 HTTP = "0.8.14"
 JSON = "0.21"
 Tar = "1.3.1"


### PR DESCRIPTION
This is holding back FilePathsBase, which is causing https://github.com/JuliaIO/FileIO.jl/pull/259#issuecomment-752931861.

If this works, it would be good to get a new release.