### PR TITLE
Add `compress_trace()`; a helper method for compressing traces

### DIFF
--- a/test/rr.jl
+++ b/test/rr.jl
@@ -50,24 +50,28 @@ using BugReporting, Test, Pkg
             @test isfile(tarzst_path)
         end
 
-        # Test that we can replay that trace: (just send in `continue` immediately to let it run)
-        new_stdout_rd, new_stdout_wr = Base.redirect_stdout()
-        new_stderr_rd, new_stderr_wr = Base.redirect_stderr()
-        new_stdin_rd, new_stdin_wr = Base.redirect_stdin()
-        write(new_stdin_wr, "continue\nquit\ny")
-        BugReporting.rr_replay(temp_trace_dir)
-        Base.redirect_stdout(old_stdout)
-        Base.redirect_stderr(old_stderr)
-        Base.redirect_stdin(old_stdin)
-        close(new_stdout_wr)
-        close(new_stderr_wr)
-        close(new_stdin_rd)
-        
-        rr_stdout = String(read(new_stdout_rd))
-        rr_stderr = String(read(new_stderr_rd))
+        # Redirect `HOME` to a directory that we know doesn't contain a `.gdbinit` file,
+        # as that can screw up the `isempty(rr_stderr)` test below
+        withenv("HOME" => temp_trace_dir) do
+            # Test that we can replay that trace: (just send in `continue` immediately to let it run)
+            new_stdout_rd, new_stdout_wr = Base.redirect_stdout()
+            new_stderr_rd, new_stderr_wr = Base.redirect_stderr()
+            new_stdin_rd, new_stdin_wr = Base.redirect_stdin()
+            write(new_stdin_wr, "continue\nquit\ny")
+            BugReporting.replay(temp_trace_dir)
+            Base.redirect_stdout(old_stdout)
+            Base.redirect_stderr(old_stderr)
+            Base.redirect_stdin(old_stdin)
+            close(new_stdout_wr)
+            close(new_stderr_wr)
+            close(new_stdin_rd)
 
-        # Test that Julia spat out what we expect, still.
-        @test occursin(msg, rr_stdout)
-        @test isempty(rr_stderr)
+            rr_stdout = String(read(new_stdout_rd))
+            rr_stderr = String(read(new_stderr_rd))
+
+            # Test that Julia spat out what we expect, still.
+            @test occursin(msg, rr_stdout)
+            @test isempty(rr_stderr)
+        end
     end
 end

--- a/test/rr.jl
+++ b/test/rr.jl
@@ -43,6 +43,13 @@ using BugReporting, Test, Pkg
         trace_files = readdir(joinpath(temp_trace_dir,"latest-trace"))
         @test !isempty(filter(f -> startswith(f, "mmap_pack_"), trace_files))
 
+        # Test that we can compress that trace directory
+        mktempdir() do temp_out_dir
+            tarzst_path = joinpath(temp_out_dir, "trace.tar.zst")
+            BugReporting.compress_trace(temp_trace_dir, tarzst_path)
+            @test isfile(tarzst_path)
+        end
+
         # Test that we can replay that trace: (just send in `continue` immediately to let it run)
         new_stdout_rd, new_stdout_wr = Base.redirect_stdout()
         new_stderr_rd, new_stderr_wr = Base.redirect_stderr()


### PR DESCRIPTION
This will be exercised by the `julia-test` buildkite plugin to allow for automated trace uploading on failure, etc...