### PR TITLE
Revoked AWSS3@0.7.5 as it uses AWSCore in the backend

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ rr_jll = "e86bdf43-55f7-5ea2-9fd0-e7daa2c0f2b4"
 
 [compat]
 AWS = "1.49"
-AWSS3 = "0.7.5, 0.8"
+AWSS3 = "0.8"
 HTTP = "0.8.14"
 JSON = "0.21"
 Tar = "1.3.1"


### PR DESCRIPTION
This has been sitting in my inbox for quite some time now. Discussion from it stemmed [here](https://github.com/JuliaLang/BugReporting.jl/commit/7dd520cd169c5e8bf824d5bb2c105d039489f332#commitcomment-47231451). [AWSS3.jl@0.7](https://github.com/JuliaCloud/AWSS3.jl/blob/v0.7.5/Project.toml#L7) uses [AWSCore.jl](https://github.com/JuliaCloud/AWSCore.jl/). While [AWSS3@0.8](https://github.com/JuliaCloud/AWSS3.jl/blob/v0.8.0/Project.toml#L6) uses the new [AWS.jl](https://github.com/JuliaCloud/AWS.jl) package. This package will not work in its current state if someone has a `AWSS3@0.7` version installed.