### PR TITLE
Switch to Downloads.jl.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.6"
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 AWSS3 = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 GDB_jll = "a8b33d9f-0f8b-5197-9986-f85cbaa50c6c"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"

--- a/src/BugReporting.jl
+++ b/src/BugReporting.jl
@@ -13,6 +13,7 @@ using HTTP, JSON
 using AWS, AWSS3
 using Tar
 using Pkg
+import Downloads
 
 # https://github.com/JuliaLang/julia/pull/29411
 if isdefined(Base, :exit_on_sigint)
@@ -150,12 +151,11 @@ function decompress_rr_trace(trace_file)
     return Pkg.artifact_path(artifact_hash)
 end
 
-function download_rr_trace(trace_url; verbose=true)
-    isdefined(Pkg.PlatformEngines, :probe_platform_engines) && Pkg.PlatformEngines.probe_platform_engines!()
+function download_rr_trace(trace_url)
     mktempdir() do dl_dir
         # Download into temporary directory, unpack into artifact directory
         local_path = joinpath(dl_dir, "trace.tar.zst")
-        Pkg.PlatformEngines.download(trace_url, local_path; verbose=verbose)
+        Downloads.download(trace_url, local_path)
         decompress_rr_trace(local_path)
     end
 end


### PR DESCRIPTION
Its `verbose` mode is very verbose, so I removed that:

```
│ * Couldn't find host 127.0.0.1 in the (nil) file; using defaults
│ *   Trying 127.0.0.1:22870...
│ * Connected to 127.0.0.1 (127.0.0.1) port 22870 (#0)
│ > GET / HTTP/1.1
│ Host: 127.0.0.1:22870
│ Accept: */*
│ User-Agent: curl/7.83.1 julia/1.8
│
│ * Mark bundle as not supporting multiuse
│ < HTTP/1.1 200 OK
│ < Transfer-Encoding: chunked
│ <
│ ┌ LogLevel(1999): handle_connection handler error
│ │   exception =
│ │    Server never wrote a response
│ │    Stacktrace:
│ │     [1] error(s::String)
│ │       @ Base ./error.jl:35
│ │     [2] handle_connection(f::Function, c::HTTP.ConnectionPool.Connection, listener::HTTP.Servers.Listener{Nothing, Sockets.TCPServer}, readtimeout::Int64, access_log::Nothing)
│ │       @ HTTP.Servers /home/tim/Julia/depot/packages/HTTP/XJG1J/src/Servers.jl:449
│ │     [3] (::HTTP.Servers.var"#16#17"{var"#8#15"{String}, HTTP.Servers.Listener{Nothing, Sockets.TCPServer}, Set{HTTP.ConnectionPool.Connection}, Int64, Nothing, Base.Semaphore, HTTP.ConnectionPool.Connection})()
│ │       @ HTTP.Servers ./task.jl:484
│ └ @ HTTP.Servers /home/tim/Julia/depot/packages/HTTP/XJG1J/src/Servers.jl:460
│ * Leftovers after chunking:  106u bytes
│ * Connection #0 to host 127.0.0.1 left intact
```