### PR TITLE
Fetch GIT_VERSION_INFO at the start of the replay.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+error()
 include("go_compile.jl")
 include("rr.jl")
 include("unittests.jl")


### PR DESCRIPTION
Toying with gdb to solve https://github.com/JuliaLang/BugReporting.jl/issues/23. I'm not really happy with this approach though: how it hooks the terminal, uses the gdb CLI, and continues past Julia's initialization to fetch Base.GIT_VERSION_INFO.