### PR TITLE
Prevent PYTHONHOME, set by Python_jll, from leaking in the Julia environment.

### DIFF
--- a/src/BugReporting.jl
+++ b/src/BugReporting.jl
@@ -126,6 +126,11 @@ function rr_record(args...; trace_dir=nothing)
         if trace_dir !== nothing
             new_env["_RR_TRACE_DIR"] = trace_dir
         end
+
+        # loading GDB_jll sets PYTHONHOME via Python_jll. this only matters for replay,
+        # and shouldn't leak into the Julia environment (which may load its own Python)
+        delete!(new_env, "PYTHONHOME")
+
         # Intersperse all given arguments with spaces, then splat:
         rr_cmd = `$(rr_path) record $(global_record_flags)`
         for arg in args


### PR DESCRIPTION
It breaks loading Python from Julia, as done by e.g. Conda.jl.

```
$ jl --bug-report=rr-local 

julia> run(`python -c "import sys; print(sys.version)"`)
Python path configuration:
  PYTHONHOME = '/home/tim/Julia/depot/artifacts/7feba47da7f679e59da788f7b564290573ea4e07'
  PYTHONPATH = (not set)
  program name = 'python'
  isolated = 0
  environment = 1
  user site = 1
  import site = 1
  sys._base_executable = '/usr/bin/python'
  sys.base_prefix = '/home/tim/Julia/depot/artifacts/7feba47da7f679e59da788f7b564290573ea4e07'
  sys.base_exec_prefix = '/home/tim/Julia/depot/artifacts/7feba47da7f679e59da788f7b564290573ea4e07'
  sys.platlibdir = 'lib'
  sys.executable = '/usr/bin/python'
  sys.prefix = '/home/tim/Julia/depot/artifacts/7feba47da7f679e59da788f7b564290573ea4e07'
  sys.exec_prefix = '/home/tim/Julia/depot/artifacts/7feba47da7f679e59da788f7b564290573ea4e07'
  sys.path = [
    '/home/tim/Julia/depot/artifacts/7feba47da7f679e59da788f7b564290573ea4e07/lib/python310.zip',
    '/home/tim/Julia/depot/artifacts/7feba47da7f679e59da788f7b564290573ea4e07/lib/python3.10',
    '/home/tim/Julia/depot/artifacts/7feba47da7f679e59da788f7b564290573ea4e07/lib/python3.10/lib-dynload',
  ]
Fatal Python error: init_fs_encoding: failed to get the Python codec of the filesystem encoding
Python runtime state: core initialized
ModuleNotFoundError: No module named 'encodings'
```