### PR TITLE
Set-up the environment outside of rr_jll's influence.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BugReporting"
 uuid = "bcf9a6e7-4020-453c-b88e-690564246bb8"
 authors = ["Keno Fischer <keno@juliacomputing.com>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"

--- a/src/BugReporting.jl
+++ b/src/BugReporting.jl
@@ -121,17 +121,16 @@ function rr_record(args...; trace_dir=nothing)
     check_rr_available()
     check_perf_event_paranoid()
 
+    new_env = copy(ENV)
+    if trace_dir !== nothing
+        new_env["_RR_TRACE_DIR"] = trace_dir
+    end
+
+    # loading GDB_jll sets PYTHONHOME via Python_jll. this only matters for replay,
+    # and shouldn't leak into the Julia environment (which may load its own Python)
+    delete!(new_env, "PYTHONHOME")
+
     rr() do rr_path
-        new_env = copy(ENV)
-        if trace_dir !== nothing
-            new_env["_RR_TRACE_DIR"] = trace_dir
-        end
-
-        # loading GDB_jll sets PYTHONHOME via Python_jll. this only matters for replay,
-        # and shouldn't leak into the Julia environment (which may load its own Python)
-        delete!(new_env, "PYTHONHOME")
-
-        # Intersperse all given arguments with spaces, then splat:
         rr_cmd = `$(rr_path) record $(global_record_flags)`
         for arg in args
             rr_cmd = `$(rr_cmd) $(arg)`


### PR DESCRIPTION
Otherwise the LD_LIBRARY_PATH put in there breaks curl, as noticed in https://github.com/JuliaLang/BugReporting.jl/issues/66.