### PR TITLE
Replace JULIA_RR_IGNORE_STATUS with isinteractive-based default.

### DIFF
--- a/src/BugReporting.jl
+++ b/src/BugReporting.jl
@@ -212,14 +212,12 @@ function replay(trace_url)
 end
 
 function handle_child_error(p::Base.Process)
-    # if the parent process is interactive, the user called `make_interactive_report`
-    # directly, so we shouldn't exit based on the child status. else, we're probably
-    # invoked through the `--bug-report` flag, so it's better to propagate the child status.
-    # If the user has requested that we ignore child status, do so
+    # if the parent process is interactive, we shouldn't exit if the child process failed.
     if isinteractive()
         return
     end
 
+    # for non-interactive sessions, likely from `--bug-report`, we want to propagate failure
     if !success(p)
         # Return the exit code if that is nonzero
         if p.exitcode != 0
@@ -231,7 +229,6 @@ function handle_child_error(p::Base.Process)
         ccall(:raise, Cint, (Cint,), p.termsignal)
     end
 end
-
 
 function make_interactive_report(report_type, ARGS=[])
     cmd = Base.julia_cmd()

--- a/test/rr.jl
+++ b/test/rr.jl
@@ -138,5 +138,13 @@ using BugReporting, Test, Pkg, HTTP
         @test isempty(stderr_lines)
 
         test_replay(temp_trace_dir)
+
+        # Test that `--bug-report` propagates the child's exit status
+        @test  success(```$(Base.julia_cmd()) --project=$(dirname(@__DIR__))
+                                              --bug-report=rr-local
+                                              --eval "exit(0)"```)
+        @test !success(```$(Base.julia_cmd()) --project=$(dirname(@__DIR__))
+                                              --bug-report=rr-local
+                                              --eval "exit(1)"```)
     end
 end

--- a/test/rr.jl
+++ b/test/rr.jl
@@ -55,7 +55,7 @@ using BugReporting, Test, Pkg, HTTP
 
             new_stdout_rd, new_stdout_wr = Base.redirect_stdout()
             new_stderr_rd, new_stderr_wr = Base.redirect_stderr()
-            try
+            proc = try
                 BugReporting.rr_record(
                     Base.julia_cmd(),
                     "-e",
@@ -68,6 +68,7 @@ using BugReporting, Test, Pkg, HTTP
                 close(new_stdout_wr)
                 close(new_stderr_wr)
             end
+            @test success(proc)
 
             String(read(new_stdout_rd)), String(read(new_stderr_rd))
         end


### PR DESCRIPTION
The main use case of JULIA_RR_IGNORE_STATUS is to make that the parent Julia session survives when calling `make_interactive_report` directly. Instead of requiring an override env flag, detect this situation using `isinteractive()`.