### PR TITLE
Add support for a record timeout.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,21 @@
-# BugReporting
+# BugReporting.jl
 
-This is a WIP to simplify bug reporting for julia by enabling users to easily
-upload rr traces (and in the future potentially other report types).
+This package implements Julia's `--bug-report` flag, simplyfing bug reporting by enabling
+users to easily generate and upload reports to help developers fix bugs.
 
-## Available bug report types
+```
+    julia --bug-report=REPORT_TYPE[,REPORT_FLAG,...]
+```
+
+Currently, only the [rr](https://github.com/rr-debugger/rr) tool is supported to generate
+bug reports, but in the future other types of reports may be supported as well.
+
+
+## Available bug report types and flags
+
+### `--bug-report=help`
+
+Print help message and exit.
 
 ### `--bug-report=rr`
 
@@ -13,9 +25,11 @@ Run `julia` inside `rr record` and upload the recorded trace.
 
 Run `julia` inside `rr record` but do not upload the recorded trace. Useful for local debugging.
 
-### `--bug-report=help`
+### `--bug-report=XXX,timeout=SECONDS`
 
-Print help message and exit.
+Generate a bug report, but limit the execution time of the debugged process to `SECONDS` seconds.
+This is useful for generating reports for hangs.
+
 
 ## Using the traces for local debugging
 

--- a/src/BugReporting.jl
+++ b/src/BugReporting.jl
@@ -530,7 +530,9 @@ function upload_rr_trace(trace_directory)
 end
 
 function __init__()
-    global default_rr_record_flags = `$(split(get(ENV, "JULIA_RR_RECORD_ARGS", ""), ' ', keepempty=false))`
+    if haskey(ENV, "JULIA_RR_RECORD_ARGS")
+        global default_rr_record_flags = eval(:(@cmd($(ENV["JULIA_RR_RECORD_ARGS"]))))
+    end
 
     global julia_checkout = @get_scratch!("julia")
 end

--- a/test/go_compile.jl
+++ b/test/go_compile.jl
@@ -1,5 +1,3 @@
-using Test
-
 # Perhaps someday we'll have a `go_jll`. ;)
 @testset "S3Vendor" begin
     @test isfile(joinpath(@__DIR__, "..", "S3Vendor_go", "main.go"))
@@ -9,20 +7,19 @@ using Test
             @info("Skipping S3Vendor compile test due to lack of `go` compiler")
             return
         end
-        
+
         gv = read(`go version`)
         m = match(r"^go version go([\d\.]+) ", String(read(`go version`)))
         if m === nothing
             @info("Skipping S3Vendor compile test due to inability to run `go version` check")
             return
         end
-        
+
         if VersionNumber(m.captures[1]) < v"1.11"
             @info("Skipping S3Vendor compile test due to outdated `go` version ($(m.captures[1]) < 1.11)")
             return
         end
 
-        @info("Testing that S3Vendor compiles...")
         run(`go build`)
         @test isfile("S3Vendor_go")
         rm("S3Vendor_go")

--- a/test/rr.jl
+++ b/test/rr.jl
@@ -169,4 +169,29 @@ end
         @test contains(output.stdout, "Located in")
         @test contains(output.stdout, r"Contains \d+ lines")
     end
+
+    # Test that we can set a timeout
+    mktempdir() do temp_trace_dir
+        t0 = time()
+        proc, output = withenv("_RR_TRACE_DIR" => temp_trace_dir) do
+            cmd = ```$(Base.julia_cmd()) --project=$(dirname(@__DIR__))
+                                         --bug-report=rr-local,timeout=2
+                                         --eval "println(\"Starting sleep\"); sleep(60)"```
+            communicate(cmd)
+        end
+        @test !success(proc)
+        t1 = time()
+        @test t1-t0 < 30
+        @test contains(output.stdout, "Starting sleep")
+
+        # the recording should be valid, despite having been killed due to a timeout
+        proc, output = communicate() do
+            BugReporting.replay(temp_trace_dir; gdb_flags=`-nh -batch`, gdb_commands=[
+                    "continue",
+                    "quit"
+                ])
+        end
+        @test success(proc)
+        @test contains(output.stdout, "Starting sleep")
+    end
 end

--- a/test/rr.jl
+++ b/test/rr.jl
@@ -1,4 +1,4 @@
-using BugReporting, Test, Pkg, HTTP
+using Pkg, HTTP
 
 # helper functions to run a command or a block of code while capturing all output
 function communicate(f::Function)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,9 @@
+using Test, BugReporting
+
+@testset "BugReporting" begin
+
 include("go_compile.jl")
 include("rr.jl")
 include("unittests.jl")
+
+end

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1,8 +1,4 @@
-module BugReportingUnitTests
-
-using BugReporting:
-    check_perf_event_paranoid, InvalidPerfEventParanoidError
-using Test
+using BugReporting: check_perf_event_paranoid, InvalidPerfEventParanoidError
 
 @testset "check_perf_event_paranoid" begin
     function check(value, rr_flags=``)
@@ -33,5 +29,3 @@ using Test
     msg = sprint(showerror, err)
     @test contains(msg, "rr needs /proc/sys/kernel/perf_event_paranoid <= 1, but it is 2")
 end
-
-end  # module

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -5,11 +5,11 @@ using BugReporting:
 using Test
 
 @testset "check_perf_event_paranoid" begin
-    function check(value, flags = "")
+    function check(value, rr_flags=``)
         mktemp() do path, io
             write(io, value)
             close(io)
-            check_perf_event_paranoid(path; record_flags=Base.shell_split(flags))
+            check_perf_event_paranoid(path; rr_flags=rr_flags)
         end
         return true
     end
@@ -17,12 +17,12 @@ using Test
     @test check("1")
     @test_throws InvalidPerfEventParanoidError check("2")
     @test_throws InvalidPerfEventParanoidError check("3")
-    @test check("2", "-n")
-    @test check("2", "--no-syscall-buffer")
+    @test check("2", `-n`)
+    @test check("2", `--no-syscall-buffer`)
 
     # Let `rr` handle these?
     @test check("non integer")
-    @test check_perf_event_paranoid("/hopefully/non/existing/path"; record_flags=String[]) === nothing
+    @test check_perf_event_paranoid("/hopefully/non/existing/path"; rr_flags=``) === nothing
 
     err = try
         check("2")


### PR DESCRIPTION
Adds support for a record timeout as suggested in https://github.com/JuliaLang/BugReporting.jl/issues/45. Doesn't introduce a separate flag to Julia, as that would require modifying InteractiveUtils.jl, but instead makes it possible to add report modifiers to the argument: `--bug-report=rr,timeout=2`. The alternative is an environment variable, but those aren't pretty.