### PR TITLE
Include stdlib sources in the trace.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "BugReporting"
 uuid = "bcf9a6e7-4020-453c-b88e-690564246bb8"
 authors = ["Keno Fischer <keno@juliacomputing.com>",
            "Tim Besard <tim.besard@gmail.com>"]
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"


### PR DESCRIPTION
Further improves the debugging experience by including stdlib sources, which we can't easily get from a plain source check-out (since that would require running parts of the build) and are available during record anyway. By registering these with GDB, we get source code for Julia frames:

```
#1  0x00007f998298d3b9 in jit_compile () at pcre.jl:134
134	    errno = ccall((:pcre2_jit_compile_8, PCRE_LIB), Cint,
Current source file is pcre.jl
Compilation directory is .
Located in /tmp/jl_jgonw1/base/pcre.jl
Contains 236 lines.
```