### PR TITLE
Fix handling of unknown commits.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "BugReporting"
 uuid = "bcf9a6e7-4020-453c-b88e-690564246bb8"
 authors = ["Keno Fischer <keno@juliacomputing.com>",
            "Tim Besard <tim.besard@gmail.com>"]
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"


### PR DESCRIPTION
Also try a little harder fetching them from the remote (merge head commits, as used by PkgEval, aren't available locally).