### PR TITLE
Remove MinIO workaround.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BugReporting"
 uuid = "bcf9a6e7-4020-453c-b88e-690564246bb8"
 authors = ["Keno Fischer <keno@juliacomputing.com>", "Tim Besard <tim.besard@gmail.com>"]
-version = "0.2.8"
+version = "0.2.9"
 
 [deps]
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"

--- a/test/rr.jl
+++ b/test/rr.jl
@@ -102,16 +102,7 @@ end
         end
 
         # Test that we can upload a trace directory, and replay it.
-        # Note that Minio requires a non-tmpfs working directory,
-        # so we don't use plain mktempdir() as /tmp is likely to be tmpfs.
-        cache_dir = if haskey(ENV, "CI")
-            # most of our Sandbox.jl-based environment is tmpfs-backed, but /cache isn't
-            "/cache"
-        else
-            get(ENV, "XDG_CACHE_HOME", joinpath(homedir(), ".cache"))
-        end
-        mkpath(cache_dir)
-        mktempdir(cache_dir) do temp_srv_dir
+        mktempdir() do temp_srv_dir
             Minio.with(; public=true, dir=temp_srv_dir) do conf
                 creds, bucket = conf
                 s3_url = "s3://$(bucket.name)/test.tar.zst"


### PR DESCRIPTION
The `/cache` detection was only working on amdci, not on PkgEval.