### PR TITLE
Make server errors loud

### DIFF
--- a/src/BugReporting.jl
+++ b/src/BugReporting.jl
@@ -544,7 +544,7 @@ function make_interactive_report(report_arg, ARGS=[])
     elseif report_type == "rr"
         mktempdir() do trace_dir
             proc = rr_record(cmd, ARGS...; trace_dir=trace_dir, timeout=timeout, chaos=chaos, extras=true)
-            "Preparing trace for upload (if your trace is large this may take a few minutes)..."
+            println("Preparing trace for upload (if your trace is large this may take a few minutes)...")
             rr_pack(trace_dir)
             params = get_upload_params()
             if params !== nothing
@@ -614,6 +614,7 @@ function get_upload_params()
             push!(c, data)
         end
     end
+    errormonitor(t)
     bind(c, t)
     connectionId = take!(c)
 


### PR DESCRIPTION
First, the `"Preparing trace for upload (if your trace is large this may take a few minutes)..."` line seems like it should be `print`-ed, so fix that.

But more importantly, I just got the following error message from BugReporting while trying to upload an rr trace:
```
[ Info: Loading BugReporting package...
ERROR: InvalidStateException: Channel is closed.
Stacktrace:
  [1] try_yieldto(undo::typeof(Base.ensure_rescheduled))
    @ Base ./task.jl:931
  [2] wait()
    @ Base ./task.jl:995
  [3] wait(c::Base.GenericCondition{ReentrantLock}; first::Bool)
    @ Base ./condition.jl:130
  [4] wait
    @ Base ./condition.jl:125 [inlined]
  [5] take_unbuffered(c::Channel{Any})
    @ Base ./channels.jl:489
  [6] take!
    @ Base ./channels.jl:466 [inlined]
  [7] get_upload_params()
    @ BugReporting ~/.julia/packages/BugReporting/Qj6TJ/src/BugReporting.jl:626
  [8] (::BugReporting.var"#33#35"{Vector{String}})(trace_dir::String)
    @ BugReporting ~/.julia/packages/BugReporting/Qj6TJ/src/BugReporting.jl:549
  [9] mktempdir(fn::BugReporting.var"#33#35"{Vector{String}}, parent::String; prefix::String)
    @ Base.Filesystem ./file.jl:766
 [10] mktempdir (repeats 2 times)
    @ Base.Filesystem ./file.jl:762 [inlined]
 [11] make_interactive_report(report_arg::String, ARGS::Vector{String})
    @ BugReporting ~/.julia/packages/BugReporting/Qj6TJ/src/BugReporting.jl:545
 [12] #invokelatest#2
    @ Base ./essentials.jl:887 [inlined]
 [13] invokelatest
    @ Base ./essentials.jl:884 [inlined]
 [14] report_bug(kind::String)
    @ InteractiveUtils ~/julia-1.10-bugtrack/usr/share/julia/stdlib/v1.10/InteractiveUtils/src/InteractiveUtils.jl:365
 [15] exec_options(opts::Base.JLOptions)
    @ Base ./client.jl:253
 [16] _start()
    @ Base ./client.jl:552
```

which I understand as meaning that the task `t` responsible for sending the upload failed, which closed channel `c` because of the `bind`, but the root error in `t` itself went silent (à la https://github.com/JuliaLang/julia/issues/51597). So, I suggest putting an `errormonitor` on `t` to at least see get a report on what went wrong there.