### PR TITLE
Split upload_rr_trace to enable manual upload.

### DIFF
--- a/test/rr.jl
+++ b/test/rr.jl
@@ -103,18 +103,20 @@ end
         end
 
         # Test that we can upload a trace directory, and replay it.
+        tarball = BugReporting.pack_rr_trace(temp_trace_dir)
         Minio.with(; public=true) do conf
             creds, bucket = conf
             s3_url = "s3://$(bucket.name)/test.tar.zst"
             http_url = bucket.baseurl * "test.tar.zst"
             endpoint_url = replace(bucket.baseurl, "$(bucket.name)/"=>"")
             withenv("S3_ENDPOINT_URL" => endpoint_url) do
-                BugReporting.upload_rr_trace(temp_trace_dir, s3_url; creds.access_key_id,
-                                             creds.secret_access_key, creds.session_token)
+                BugReporting.upload_rr_tarball(tarball, s3_url; creds.access_key_id,
+                                               creds.secret_access_key, creds.session_token)
             end
 
             test_replay(http_url)
         end
+        rm(tarball)
     end
 
     # Test that the --bug-report mode works


### PR DESCRIPTION
Automatic uploading of the trace can sometimes fail, see e.g. https://github.com/JuliaGPU/CUDA.jl/issues/2163#issuecomment-1811117317. In this PR, I provide a fallback, where the user can still manually upload a trace if the upload was interrupted or canceled.

@Liozou I changed the `errormonitor` logic you added in #144; IIUC all errors should have been reported by `errormonitor`, so it should be safe to just return from the `catch` block.